### PR TITLE
Events Publisher/Subscriber creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Indeed, Feathers does not allow to register new services after the app has been 
 
 ### Events
 
-By default all [real-time events](https://docs.feathersjs.com/api/events.html) from local services are distributed to remote ones but you can customize the events to be dispatched by providing the list in the `distributedEvents` property of your service.
+By default all [real-time events](https://docs.feathersjs.com/api/events.html) from local services are distributed to remote ones but you can customize the events to be dispatched by providing the list in the `distributedEvents` property of your service or disable all events publishing with the `publishEvents` boolean option.
 
 ## Hooks
 

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,8 @@ export default function init (options = {}) {
     app.distributionOptions = Object.assign({
       publicationDelay: process.env.PUBLICATION_DELAY || 10000,
       coteDelay: process.env.COTE_DELAY,
-      middlewares: {}
+      middlewares: {},
+      publishEvents: true
     }, options)
 
     debug('Initializing feathers-distributed with options', app.distributionOptions)

--- a/src/service.js
+++ b/src/service.js
@@ -23,7 +23,7 @@ class RemoteService {
     this.path = path
     debug('Requester created for remote service on path ' + this.path)
 
-    if (this.remoteEvents.length) {
+    if (app.distributionOptions.publishEvents && this.remoteEvents.length) {
       // Create the subscriber to listen to events from other nodes
       this.serviceEventsSubscriber = new app.cote.Subscriber({
         name: path + ' events subscriber',

--- a/src/service.js
+++ b/src/service.js
@@ -22,20 +22,23 @@ class RemoteService {
     }, app.coteOptions)
     this.path = path
     debug('Requester created for remote service on path ' + this.path)
-    // Create the subscriber to listen to events from other nodes
-    this.serviceEventsSubscriber = new app.cote.Subscriber({
-      name: path + ' events subscriber',
-      namespace: path,
-      key: path,
-      subscribesTo: this.remoteEvents
-    }, app.coteOptions)
-    this.remoteEvents.forEach(event => {
-      this.serviceEventsSubscriber.on(event, object => {
-        debug(`Dispatching ${event} remote service event on path ` + path, object)
-        this.emit(event, object)
+
+    if (this.remoteEvents.length) {
+      // Create the subscriber to listen to events from other nodes
+      this.serviceEventsSubscriber = new app.cote.Subscriber({
+        name: path + ' events subscriber',
+        namespace: path,
+        key: path,
+        subscribesTo: this.remoteEvents
+      }, app.coteOptions)
+      this.remoteEvents.forEach(event => {
+        this.serviceEventsSubscriber.on(event, object => {
+          debug(`Dispatching ${event} remote service event on path ` + path, object)
+          this.emit(event, object)
+        })
       })
-    })
-    debug('Subscriber created for remote service events on path ' + this.path, this.remoteEvents)
+      debug('Subscriber created for remote service events on path ' + this.path, this.remoteEvents)
+    }
   }
 
   // Perform requests to other nodes
@@ -158,20 +161,22 @@ class LocalService extends cote.Responder {
       return result
     })
 
-    // Dispatch events to other nodes
-    this.serviceEventsPublisher = new app.cote.Publisher({
-      name: path + ' events publisher',
-      namespace: path,
-      key: path,
-      broadcasts: options.events
-    }, app.coteOptions)
-    options.events.forEach(event => {
-      service.on(event, object => {
-        debug(`Publishing ${event} local service event on path ` + path, object)
-        this.serviceEventsPublisher.publish(event, object)
+    if (app.distributionOptions.publishEvents && options.events.length) {
+      // Dispatch events to other nodes
+      this.serviceEventsPublisher = new app.cote.Publisher({
+        name: path + ' events publisher',
+        namespace: path,
+        key: path,
+        broadcasts: options.events
+      }, app.coteOptions)
+      options.events.forEach(event => {
+        service.on(event, object => {
+          debug(`Publishing ${event} local service event on path ` + path, object)
+          this.serviceEventsPublisher.publish(event, object)
+        })
       })
-    })
-    debug('Publisher created for local service events on path ' + path, options.events)
+      debug('Publisher created for local service events on path ' + path, options.events)
+    }
   }
 }
 


### PR DESCRIPTION
When Feathers service doesn't have any events, there's no need to open event type publisher & subscriber connection on Redis/Network. for example, when `service.distributedEvents` is set to `[]`.

In addition, in a project that doesn't use Feathers events at all as design choice, it is very cumbersome to verify that every service will have the `distributedEvents` option set to `[]`, so I've added a new `publishEvents` option to disable events publishing globally to all events.

Changes are:
- Events Publisher/Subscriber will be created only when service has events
- Added new distributed boolean option: publishEvents