### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/kalisio/feathers-distributed/issues"
   },
   "scripts": {
-    "prepublish": "npm run compile",
+    "prepare": "npm run compile",
     "publish": "git push origin --tags && npm run changelog && git push origin",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",


### PR DESCRIPTION
Changement de "prepublish" en "prepare" afin que le build ce fasse lors de l'installation avec npm sur le repo git afin d'avoir la dernière version.

### Summary
- Correct npm install https://github.com/kalisio/feathers-distributed --save

### Other Information
https://docs.npmjs.com/misc/scripts